### PR TITLE
[APP-41738]pusher ignores Request too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ and update etcdclient to v3
 
 deprecates 17media/go-etcd
 
-note that we ignore errors that files are too large to push (limitation for server side: 1.5 MiB, client side: 4 MiB), because they are not etcd meant to maintain
+note that we ignore errors that files are too large to push (limitation for server side: 1.5 MiB, client side: 2 MiB), because they are not etcd meant to maintain
 
 see
-https://etcd.io/docs/v3.3/upgrades/upgrade_3_2/#changed-maximum-request-size-limits-3210 .
+https://etcd.io/docs/v3.3/upgrades/upgrade_3_2/#changed-maximum-request-size-limits-3210 (old change log),
+
+https://github.com/etcd-io/etcd/blob/08407ff7600eb16c4445d5f21c4fafaf19412e24/client/v3/config.go#L46
 
 
 # TODO

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ and update etcdclient to v3
 
 deprecates 17media/go-etcd
 
+note that we ignore errors that files are too large to push (limitation for server side: 1.5 MiB, client side: 4 MiB), because they are not etcd meant to maintain
+
+see
+https://etcd.io/docs/v3.3/upgrades/upgrade_3_2/#changed-maximum-request-size-limits-3210 .
+
+
 # TODO
 
 for pusher, 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/BurntSushi/cmd v0.0.0-20121122232022-d54777ad4400
 	github.com/facebookgo/stats v0.0.0-20151006221625-1b76add642e4
 	github.com/stretchr/testify v1.7.0
+	go.etcd.io/etcd v3.3.27+incompatible
 	go.etcd.io/etcd/client/v3 v3.5.1
 	google.golang.org/grpc v1.38.0
 )

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.etcd.io/etcd v3.3.27+incompatible h1:5hMrpf6REqTHV2LW2OclNpRtxI0k9ZplMemJsMSWju0=
+go.etcd.io/etcd v3.3.27+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
 go.etcd.io/etcd/api/v3 v3.5.1 h1:v28cktvBq+7vGyJXF8G+rWJmj+1XUmMtqcLnH8hDocM=
 go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.1 h1:XIQcHCFSG53bJETYeRJtIxdLv2EWRGxcfzR8lSnTH4E=

--- a/pusher/main.go
+++ b/pusher/main.go
@@ -359,7 +359,7 @@ func Pusher(etcdConn *clientv3.Client, root, etcdRoot string) {
 		// error msg in the document is slightly off, so we define it here.
 		// ErrRequestTooLarge comes from go.etcd.io/etcd v3.3.27+incompatible, but we are only using string so it should be find
 		if err != nil && (strings.HasPrefix(err.Error(), clientTooLargeErr) || err.Error() == rpctypes.ErrRequestTooLarge.Error()) {
-			fmt.Printf("file %s\n is too large, error: %s\n", fileP, err.Error())
+			log.Printf("file %s\n is too large, error: %s\n", fileP, err.Error())
 		} else if err != nil {
 			log.Fatalf("error when putting >%s(%s + %s)<. Config server will be inconsistent: %s",
 				fileP, remoteRoot, k, err)

--- a/pusher/main.go
+++ b/pusher/main.go
@@ -357,7 +357,7 @@ func Pusher(etcdConn *clientv3.Client, root, etcdRoot string) {
 		if err == rpctypes.ErrRequestTooLarge || strings.HasPrefix(err.Error(), "rpc error: code = ResourceExhausted desc = grpc: trying to send message larger than max") {
 			fmt.Printf("file %s\n is too large, error: %s", fileP, err.Error())
 		} else if err != nil {
-			log.Fatalf("error when setting znode >%s(%s + %s)<. Config server will be inconsistent: %s",
+			log.Fatalf("error when putting >%s(%s + %s)<. Config server will be inconsistent: %s",
 				fileP, remoteRoot, k, err)
 		}
 	}

--- a/pusher/main.go
+++ b/pusher/main.go
@@ -359,7 +359,7 @@ func Pusher(etcdConn *clientv3.Client, root, etcdRoot string) {
 		// error msg in the document is slightly off, so we define it here.
 		// ErrRequestTooLarge comes from go.etcd.io/etcd v3.3.27+incompatible, but we are only using string so it should be find
 		if err != nil && (strings.HasPrefix(err.Error(), clientTooLargeErr) || err.Error() == rpctypes.ErrRequestTooLarge.Error()) {
-			fmt.Printf("file %s\n is too large, error: %s", fileP, err.Error())
+			fmt.Printf("file %s\n is too large, error: %s\n", fileP, err.Error())
 		} else if err != nil {
 			log.Fatalf("error when putting >%s(%s + %s)<. Config server will be inconsistent: %s",
 				fileP, remoteRoot, k, err)

--- a/pusher/run.sh
+++ b/pusher/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 go run main.go \
-  -csi.config.repo.root="$GOPATH/src/github.com/17media/configs/envs/dev"\
-  -csi.config.etcd.root="/configs/envs/dev" \
+  -csi.config.repo.root="$GOPATH/src/github.com/17media/configs/envs/prod"\
+  -csi.config.etcd.root="/configs/envs/prod" \
   -csi.config.etcd.machines="http://127.0.0.1:12379"

--- a/pusher/run.sh
+++ b/pusher/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 go run main.go \
-  -csi.config.repo.root="$GOPATH/src/github.com/17media/configs/envs/prod"\
-  -csi.config.etcd.root="/configs/envs/prod" \
+  -csi.config.repo.root="$GOPATH/src/github.com/17media/configs/envs/dev"\
+  -csi.config.etcd.root="/configs/envs/dev" \
   -csi.config.etcd.machines="http://127.0.0.1:12379"


### PR DESCRIPTION
test result: 
<img width="1042" alt="截圖 2022-06-02 下午6 40 59" src="https://user-images.githubusercontent.com/64002049/171612657-10d6ddd9-973e-4fb6-95ed-6817f10e65cf.png">


https://etcd.io/docs/v3.3/upgrades/upgrade_3_2/#changed-maximum-request-size-limits-3210
(Warning! the format here is slightly off)

https://17media.slack.com/archives/C02Q6EVAWTX/p1652761254698949

https://17media.atlassian.net/browse/APP-41738